### PR TITLE
feat: Add System Prompt Management Methods

### DIFF
--- a/gemini/src/gemini/ask.rs
+++ b/gemini/src/gemini/ask.rs
@@ -66,6 +66,14 @@ impl Gemini {
         self.model = model.into();
         self
     }
+    pub fn set_sys_prompt(mut self, sys_prompt: SystemInstruction) -> Self {
+        self.sys_prompt = Some(sys_prompt);
+        self
+    }
+    pub fn remove_sys_prompt(mut self) -> Self {
+        self.sys_prompt = None;
+        self
+    }
     pub fn set_api_key(mut self, api_key: impl Into<String>) -> Self {
         self.api_key = api_key.into();
         self

--- a/gemini/src/gemini/ask.rs
+++ b/gemini/src/gemini/ask.rs
@@ -66,12 +66,8 @@ impl Gemini {
         self.model = model.into();
         self
     }
-    pub fn set_sys_prompt(mut self, sys_prompt: SystemInstruction) -> Self {
-        self.sys_prompt = Some(sys_prompt);
-        self
-    }
-    pub fn remove_sys_prompt(mut self) -> Self {
-        self.sys_prompt = None;
+    pub fn set_sys_prompt(mut self, sys_prompt: Option<SystemInstruction>) -> Self {
+        self.sys_prompt = sys_prompt;
         self
     }
     pub fn set_api_key(mut self, api_key: impl Into<String>) -> Self {


### PR DESCRIPTION
This PR adds minor but useful enhancements to the `Gemini` client, allowing for dynamic management of the system prompt after the client has been initialized.

#### Changes

*   **`set_sys_prompt(self, sys_prompt: SystemInstruction) -> Self`**: A new method to add or replace the system prompt on an existing `Gemini` instance.
*   **`remove_sys_prompt(self) -> Self`**: A new method to remove the system prompt from an existing `Gemini` instance.