### PR TITLE
Fix: Stabilize Streaming by Implementing Robust SSE Handling

### DIFF
--- a/gemini/src/gemini/ask.rs
+++ b/gemini/src/gemini/ask.rs
@@ -155,7 +155,7 @@ impl Gemini {
         F: FnMut(&Session, GeminiResponse) -> StreamType,
     {
         let req_url = format!(
-            "{BASE_URL}/{}:streamGenerateContent?key={}",
+            "{BASE_URL}/{}:streamGenerateContent?alt=sse&key={}",
             self.model, self.api_key
         );
 
@@ -187,6 +187,7 @@ impl Gemini {
             Box::new(response.bytes_stream()),
             session,
             data_extractor,
+            Vec::new(),
         ))
     }
     /// # Warning

--- a/gemini/src/gemini/ask.rs
+++ b/gemini/src/gemini/ask.rs
@@ -187,7 +187,6 @@ impl Gemini {
             Box::new(response.bytes_stream()),
             session,
             data_extractor,
-            Vec::new(),
         ))
     }
     /// # Warning


### PR DESCRIPTION
This PR addresses a critical issue in the streaming implementation that caused deserialization failures, particularly when `includeThoughts` was enabled. The previous logic was not robust enough to handle JSON payloads split across multiple network chunks, a common occurrence in streaming scenarios.

#### The Problem

The old streaming implementation assumed that each data chunk received from the network contained a complete or near-complete JSON object. This assumption broke down when the Gemini API sent bigger, most frequent updates (like with "thoughts"), leading to fragmented JSON. Attempting to parse these incomplete fragments resulted in `InvalidResposeFormat` errors and an unstable streaming experience.

#### The Solution

The streaming logic has been completely reworked to correctly implement the Server-Sent Events (SSE) protocol, which is [the standard for Gemini streaming](https://ai.google.dev/api/generate-content#method:-models.streamgeneratecontent).

1.  **Explicit SSE Request**: The client now requests the stream in SSE format by adding the `?alt=sse` query parameter to the request URL.
2.  **Buffering Mechanism**: A `buffer` has been added to `ResponseStream`. It accumulates incoming bytes from the network until a complete SSE message (terminated by `\r\n\r\n`) is formed.
3.  **Correct SSE Parsing**: The `poll_next` method now processes the buffer, extracts complete messages, strips the standard `data:` prefix, and only then attempts to deserialize the JSON payload.

This ensures that the JSON parser always receives a complete and valid string, eliminating the errors caused by fragmentation.