### PR TITLE
feat: Add support for model thoughts

### DIFF
--- a/gemini/src/gemini/ask.rs
+++ b/gemini/src/gemini/ask.rs
@@ -62,6 +62,21 @@ impl Gemini {
         }
         self.generation_config.as_mut().unwrap()
     }
+    pub fn set_thinking_config(mut self, config: ThinkingConfig) -> Self {
+        if let Value::Object(map) = self.set_generation_config() {
+            if let Ok(thinking_value) = serde_json::to_value(config) {
+                map.insert("thinking_config".to_string(), thinking_value);
+            }
+        }
+        self
+    }
+    pub fn set_thoughts_enabled(mut self, enabled: bool) -> Self {
+        let thinking = serde_json::to_value(ThinkingConfig::new(enabled, -1)).unwrap();
+        if let Value::Object(map) = self.set_generation_config() {
+            map.insert("thinking_config".to_string(), thinking);
+        }
+        self
+    }
     pub fn set_model(mut self, model: impl Into<String>) -> Self {
         self.model = model.into();
         self

--- a/gemini/src/gemini/tests/utils.rs
+++ b/gemini/src/gemini/tests/utils.rs
@@ -33,7 +33,7 @@ async fn process() {
     assert_eq!(parts.len(), 5);
     assert_eq!(
         json!(parts[2]),
-        json!(Part::text(".  thanks thanks ![but fire](https://th.bing.com/th?id=ORMS.0ba175d4898e31ae84dc62d9cd09ec84&pid=Wdp&w=612&h=304&qlt=90&c=1&rs=1&dpr=1.5&p=0)".to_string()))
+        json!(Part::text(".  thanks thanks ![but fire](https://th.bing.com/th?id=ORMS.0ba175d4898e31ae84dc62d9cd09ec84&pid=Wdp&w=612&h=304&qlt=90&c=1&rs=1&dpr=1.5&p=0)".into()))
     );
 }
 
@@ -44,5 +44,5 @@ async fn process_with_error() {
     let parts = parser.process();
     assert_eq!(GeminiResponse::extract_text(&parts, ""), markdown);
     assert_eq!(parts.len(), 3);
-    assert_eq!(json!(parts[2]), json!(Part::text(".".to_string())));
+    assert_eq!(json!(parts[2]), json!(Part::text(".".into())));
 }

--- a/gemini/src/gemini/utils.rs
+++ b/gemini/src/gemini/utils.rs
@@ -155,7 +155,7 @@ impl<'a> MarkdownToParts<'a> {
             {
                 let end = index + length - removed_length;
                 let text = &self.markdown[..end];
-                parts.push(Part::text(text.to_string()));
+                parts.push(Part::text(text.into()));
                 parts.push(Part::inline_data(InlineData::new(mime_type, base64)));
 
                 self.markdown = &self.markdown[end..];
@@ -163,7 +163,7 @@ impl<'a> MarkdownToParts<'a> {
             }
         }
         if self.markdown.len() != 0 {
-            parts.push(Part::text(self.markdown.to_string()));
+            parts.push(Part::text(self.markdown.into()));
         }
         parts
     }


### PR DESCRIPTION
This PR introduces support for receiving and handling the model's "thoughts" from the Gemini API. This allows users to inspect the model's reasoning process during generation, which is especially useful for streaming responses.

#### Key Changes:

**Thinking Configuration**:
    *   Added a `ThinkingConfig` struct to control the feature via `generationConfig`.
    *   Introduced a new convenience method `Gemini::set_thoughts_enabled(bool)` to easily enable or disable this feature.

**Part Deserialization**:
    *   The Gemini API uses a different structure for thoughts (`{"text": "...", "thought": true}`) than for regular text (`{"text": "..."}`). To handle this without turning the `Part` enum into a struct and causing major breaking changes, a new internal `TextPart` struct (`{text: String, thought: bool}`) was created.
    *   Custom `Serialize` and `Deserialize` logic was implemented for the `Part` enum. This allows the client to correctly parse both regular text and thought parts while maintaining the enum structure for the library's public API.

*   **Response and Session Helpers**:
    *   `GeminiResponse` now has methods to distinguish thought chunks from final answer chunks:
        *   `is_thinking()`: Checks if a response chunk is a thought.
        *   `get_text_no_think()`: Extracts only the final answer text, filtering out thoughts.
    *   `Session` has been updated to correctly manage and retrieve thoughts:
        *   `get_last_message_text()`: Now correctly returns only the final answer, excluding thoughts.
        *   `get_last_message_thoughts()`: A new method to specifically retrieve the text from thoughts.

***IMPORTANT:*** Streaming with thoughts will NOT work correctly without the fixes in PR #3.