### PR TITLE
Add support for Safety Settings

### DIFF
--- a/gemini/src/gemini/ask.rs
+++ b/gemini/src/gemini/ask.rs
@@ -15,6 +15,7 @@ pub struct Gemini {
     model: String,
     sys_prompt: Option<SystemInstruction>,
     generation_config: Option<Value>,
+    safety_settings: Option<Vec<SafetySetting>>,
     tools: Option<Vec<Tool>>,
 }
 impl Gemini {
@@ -36,6 +37,7 @@ impl Gemini {
             model: model.into(),
             sys_prompt,
             generation_config: None,
+            safety_settings: None,
             tools: None,
         }
     }
@@ -52,6 +54,7 @@ impl Gemini {
             model: model.into(),
             sys_prompt,
             generation_config: None,
+            safety_settings: None,
             tools: None,
         }
     }
@@ -83,6 +86,10 @@ impl Gemini {
     }
     pub fn set_sys_prompt(mut self, sys_prompt: Option<SystemInstruction>) -> Self {
         self.sys_prompt = sys_prompt;
+        self
+    }
+    pub fn set_safety_settings(mut self, settings: Option<Vec<SafetySetting>>) -> Self {
+        self.safety_settings = settings;
         self
     }
     pub fn set_api_key(mut self, api_key: impl Into<String>) -> Self {
@@ -130,6 +137,7 @@ impl Gemini {
                 self.tools.as_deref(),
                 &session.get_history().as_slice(),
                 self.generation_config.as_ref(),
+                self.safety_settings.as_deref(),
             ))
             .send()
             .await
@@ -186,6 +194,7 @@ impl Gemini {
                 self.tools.as_deref(),
                 session.get_history().as_slice(),
                 self.generation_config.as_ref(),
+                self.safety_settings.as_deref(),
             ))
             .send()
             .await;

--- a/gemini/src/gemini/types/request.rs
+++ b/gemini/src/gemini/types/request.rs
@@ -292,6 +292,29 @@ impl SystemInstruction {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum HarmCategory {
+    HarmCategoryHarassment,
+    HarmCategoryHateSpeech,
+    HarmCategorySexuallyExplicit,
+    HarmCategoryDangerousContent,
+}
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BlockThreshold {
+    BlockNone,
+    BlockOnlyHigh,
+    BlockMediumAndAbove,
+    BlockLowAndAbove,
+}
+#[derive(Serialize, Deserialize, new, Getters, Debug, Clone)]
+pub struct SafetySetting {
+    pub category: HarmCategory,
+    pub threshold: BlockThreshold,
+}
+
 #[allow(non_snake_case)]
 #[derive(Serialize, new)]
 pub struct GeminiRequestBody<'a> {
@@ -301,6 +324,8 @@ pub struct GeminiRequestBody<'a> {
     contents: &'a [&'a Chat],
     #[serde(skip_serializing_if = "Option::is_none")]
     generationConfig: Option<&'a Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    safetySettings: Option<&'a [SafetySetting]>,
 }
 
 #[derive(Serialize, Debug, Clone)]


### PR DESCRIPTION
This PR adds support for the `safetySettings` parameter, allowing users to control content moderation by adjusting block thresholds for various harm categories.

The `Gemini` client now includes a `set_safety_settings()` method for easy configuration.

**Example:**

```rust
let safety_settings = vec![
    SafetySetting::new(
        HarmCategory::HarmCategoryHateSpeech,
        BlockThreshold::BlockNone
    ),
    SafetySetting::new(
        HarmCategory::HarmCategorySexuallyExplicit,
        BlockThreshold::BlockMediumAndAbove 
    ),
];

let ai = Gemini::new(/*...*/)
    .set_safety_settings(Some(safety_settings));

let response = ai.ask(&mut session).await.unwrap();
```

### Official Documentation
[**Google AI Safety Settings Documentation**](https://ai.google.dev/gemini-api/docs/safety-settings)